### PR TITLE
Fix the "twemoji billed cap" GH link @ hats page

### DIFF
--- a/hats/index.html
+++ b/hats/index.html
@@ -104,7 +104,7 @@
     <div class="container">
       <div class="row">
         <p>"wear many hats": <i>to have many jobs or roles</i>. <a href="https://www.merriam-webster.com/dictionary/wear%20many%20hats">merriam-webster</a>
-        <br>hat image based on the <a href="https://github.com/twitter/twemoji/blob/gh-pages/2/svg/1f9e2.svg">twemoji billed cap</a>
+        <br>hat image based on the <a href="https://github.com/twitter/twemoji/blob/d94f4cf/assets/svg/1f9e2.svg">twemoji billed cap</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Over time, moving targets like Git branches or tags may disappear or change. This happened to the hat emoji SVG link and the link is pointing to a 404 on GitHub. This patch fixes that by using an immutable link to the image source — it won't disappear unless the target repository starts force-pushing stuff and the commit gets garbage-collected.